### PR TITLE
rspec用のジェネレーターを修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,9 +25,7 @@ module Techlog
         fixtures: false,
         view_specs: false,
         helper_specs: false,
-        routing_specs: false,
-        controller_specs: true,
-        request_specs: false
+        routing_specs: false
     end
     
     # Configuration for the application, engines, and railties goes here.


### PR DESCRIPTION
# 実施タスク
rspec用のジェネレーターを修正 #26

# 実施内容
- controller_specs: trueを削除しました
- request_specs: falseを削除しました

# レビューして欲しいこと
- `bundle exec rails g controller Home top`を実行すると、`spec/requests/home_spec.rb`が生成されること
